### PR TITLE
Change configuration as node parameters

### DIFF
--- a/behaviorfleets/bt_xml/test.xml
+++ b/behaviorfleets/bt_xml/test.xml
@@ -7,7 +7,7 @@
         exclude ="dummy17"   
         mission_id="generic"
         plugins=""
-        remote_tree="remote_dummy.xml"
+        remote_tree="{behavior_tree_xml}"
         timeout="1"
         max_tries=""/>
     </BehaviorTree>

--- a/behaviorfleets/bt_xml/test_id.xml
+++ b/behaviorfleets/bt_xml/test_id.xml
@@ -2,7 +2,7 @@
 <root main_tree_to_execute="BehaviorTree" BTCPP_format="4">
     <!-- ////////// -->
     <BehaviorTree ID="BehaviorTree">
-        <Action ID="DelegateActionNode" remote_id="dummy" mission_id="generic" remote_tree="remote_dummy.xml"/>
+        <Action ID="DelegateActionNode" remote_id="dummy" mission_id="generic" remote_tree="{behavior_tree_xml}"/>
     </BehaviorTree>
     <!-- ////////// -->
     <TreeNodesModel>

--- a/behaviorfleets/bt_xml/wait.xml
+++ b/behaviorfleets/bt_xml/wait.xml
@@ -7,7 +7,7 @@
         exclude ="dummy1"   
         mission_id="generic"
         plugins=""
-        remote_tree="remote_dummy.xml"
+        remote_tree="{behavior_tree_xml}"
         timeout="1"
         max_tries=""/>
     </BehaviorTree>

--- a/behaviorfleets/params/params.yaml
+++ b/behaviorfleets/params/params.yaml
@@ -1,0 +1,14 @@
+source_tree:
+  ros__parameters:
+    plugins:
+      - delegate_action_node
+    behavior_tree_xml: test.xml
+
+remote_tree:
+  ros__parameters:
+    source_tree: /bt_xml/test.xml
+    nodes: 5
+    missions:
+      - generic
+      - generic
+      - non-generic

--- a/behaviorfleets/src/behaviorfleets/DelegateActionNode.cpp
+++ b/behaviorfleets/src/behaviorfleets/DelegateActionNode.cpp
@@ -53,13 +53,6 @@ DelegateActionNode::DelegateActionNode(
   RCLCPP_INFO(node_->get_logger(), "remote tree: %s", remote_tree_.c_str());
   RCLCPP_INFO(node_->get_logger(), "mission id: %s", mission_id_.c_str());
 
-  xml_path = pkgpath + remote_tree_;
-  RCLCPP_INFO(node_->get_logger(), "xml_path: %s", xml_path.c_str());
-  std::ifstream file(xml_path);
-  std::ostringstream contents_stream;
-  contents_stream << file.rdbuf();
-  remote_tree_ = contents_stream.str();
-
   mission_pub_ = node_->create_publisher<bf_msgs::msg::Mission>(
     "/mission_poll", 100);
 

--- a/behaviorfleets/src/exec/bb_source_main.cpp
+++ b/behaviorfleets/src/exec/bb_source_main.cpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <memory>
 #include <fstream>
-#include <boost/any.hpp>
+#include <streambuf>
 
 #include "behaviortree_cpp/behavior_tree.h"
 #include "behaviortree_cpp/bt_factory.h"
@@ -26,68 +26,67 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "yaml-cpp/yaml.h"
-
 #include "behaviorfleets/BlackboardManager.hpp"
 
 int main(int argc, char * argv[])
 {
-  std::string params_file = "config.yaml";
-
-  if (argc > 1) {
-    params_file = std::string(argv[1]);
-  }
-
   rclcpp::init(argc, argv);
 
+  // Read node parameters
   auto node = rclcpp::Node::make_shared("source_tree");
+  node->declare_parameter("plugins", std::vector<std::string>({}));
+  node->declare_parameter("behavior_tree_xml", "");
 
+  std::vector<std::string> plugins;
+  std::string bt_xml_filename;
+  node->get_parameter("plugins", plugins);
+  node->get_parameter("behavior_tree_xml", bt_xml_filename);
+
+  if (bt_xml_filename == "") {
+    RCLCPP_ERROR(node->get_logger(), "BT XML Filename void");
+    return -1;
+  }
+
+  // Loading plugins from parameters
   BT::SharedLibrary loader;
   BT::BehaviorTreeFactory factory;
 
-  factory.registerFromPlugin(loader.getOSName("delegate_action_node"));
-
-  std::string pkgpath = ament_index_cpp::get_package_share_directory("behaviorfleets");
-
-  std::string xml_file;
-
-  try {
-    // Load the XML path from the YAML file
-    std::cout << "Configuration file: " << params_file << std::endl;
-    std::ifstream fin(pkgpath + "/params/" + params_file);
-    YAML::Node params = YAML::Load(fin);
-
-    xml_file = pkgpath + params["source_tree"].as<std::string>();
-
-  } catch (YAML::Exception & e) {
-    std::cerr << "Error loading YAML file: " << e.what() << std::endl;
-    return 1;
-  } catch (std::exception & e) {
-    std::cerr << "Error: " << e.what() << std::endl;
-    return 1;
+  RCLCPP_INFO_STREAM(node->get_logger(), "Loading " << plugins.size() << " plugins" << ":");
+  for (const auto & plugin : plugins) {
+    RCLCPP_INFO_STREAM(node->get_logger(), "\t" << plugin);
+    factory.registerFromPlugin(loader.getOSName(plugin));
   }
 
-  auto blackboard = BT::Blackboard::create();
-  blackboard->set("node", node);
-  blackboard->set("pkgpath", pkgpath + "/bt_xml/");
+  // Read Behavior Tree XML file into an string
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("behaviorfleets");
+  std::string xml_file = pkgpath + "/bt_xml/" + bt_xml_filename;
+  RCLCPP_INFO_STREAM(node->get_logger(), "Loading " << xml_file);
+  std::ifstream ifs_xml(xml_file);
+  std::string str_xml(
+    (std::istreambuf_iterator<char>(ifs_xml)),
+    std::istreambuf_iterator<char>());
 
-  BT::Tree tree = factory.createTreeFromFile(xml_file, blackboard);
 
-  std::cout << "\t- Tree created from file" << std::endl;
-
-  rclcpp::Rate rate(0.2);
-
+  // Create Tree from XML readed and init blackboard, inserting XML on it to be used from BT nodes
   auto bb_manager = std::make_shared<BF::BlackboardManager>();
+  auto blackboard = BT::Blackboard::create();
+  blackboard->set("node", bb_manager);
+  blackboard->set("bt_xml", str_xml);
 
+  BT::Tree tree = factory.createTreeFromText(str_xml, blackboard);
+
+  RCLCPP_INFO_STREAM(node->get_logger(), "Tree created from file" << xml_file);
+
+  // Execute tree
+  rclcpp::Rate rate(0.2);
   bool finish = false;
   while (!finish && rclcpp::ok()) {
     finish = tree.rootNode()->executeTick() != BT::NodeStatus::RUNNING;
     rclcpp::spin_some(bb_manager);
-    rclcpp::spin_some(node);
     rate.sleep();
   }
 
-  std::cout << "Finished" << std::endl;
+  RCLCPP_INFO_STREAM(node->get_logger(), "Finished ");
   rclcpp::shutdown();
   return 0;
 }

--- a/behaviorfleets/src/exec/remote_main.cpp
+++ b/behaviorfleets/src/exec/remote_main.cpp
@@ -43,8 +43,6 @@ int main(int argc, char * argv[])
 
   exec.spin();
 
-  // rclcpp::spin(node);
-
   rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
Hi @rodperex 

This PR is not intended to be ready for merge, only for discussion. We could work on this PR to get a consensus ;)

Main changes:
- All the configuration is read from node parameters instead of using the yaml library. This makes it more standard and avoids direct dependencies with the yaml library.
- The XML tree (not the filename) is inserted in the blackboard under the `behavior_tree_xml` key. Using the input port is unnecessary, but I left it as it was. Consider reading it directly inside the BT node.
- in `bb_source_main.cpp` I used directly `bb_manager` as a `rclcpp::Node` instead of using an auxiliary one. Does it fits for you?

I hope you like the changes. They are only improvement suggestions that I think will help us in the next steps.

